### PR TITLE
Nix pending_keys insertion

### DIFF
--- a/MasterSetup.sql
+++ b/MasterSetup.sql
@@ -71,19 +71,6 @@ BEGIN
         pg_get_serial_sequence('dbmirror2.pending_data', 'seqid')
     );
 
-    INSERT INTO dbmirror2.pending_keys (tablename, keys)
-    VALUES (
-        _tablename,
-        (
-            SELECT array_agg(column_name)
-            FROM dbmirror2.column_info
-            WHERE table_schema = TG_TABLE_SCHEMA
-            AND table_name = TG_TABLE_NAME
-            AND is_primary = TRUE
-        )
-    )
-    ON CONFLICT DO NOTHING;
-
     INSERT INTO dbmirror2.pending_ts (xid, ts)
     VALUES (txid_current(), transaction_timestamp())
     ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Due to the way ExportAllTables works in musicbrainz-server, there's currently a race condition preventing the pending_keys table from being updated in some cases. The result is that some replication packets are missing table names from the pending_keys file which are clearly present in the pending_data file.

Important: there's no issue with pending_data or pending_ts, so the integrity of existing dbmirror2 packets is otherwise fine. Also, fortunately, there's nothing critical about the pending_keys data; it's not even needed to apply the packets on the mirror side, since primary keys can be found by querying the running database.

But back to the actual issue. When producing a replication packet (which always happens within a serializable transaction), there are two steps with respect to the pending_keys table:

 * `COPY (SELECT * FROM dbmirror2.pending_keys) TO STDOUT` (roughly)
 * `DELETE FROM dbmirror2.pending_keys`

There are also two situations where we produce replications packets: with or without a full export. Let's call these full-export and standalone packets respectively.

 * full-export packets are only produced twice a week, on Wed and Sat, from daily.sh. They're dumped from within the same serializable transaction that the full export is, so that the data in the packet is consistent with the replication sequence of the dump.
 * standalone packets are produced hourly, from hourly.sh. They can't overlap with a full export; a file lock ensures only one `MusicBrainz::Script::DatabaseDump` instance is running at a time.

There's nothing intrinsically different about either of these types of packets. They're just timed such that full exports can be logically consistent with their starting sequence.

The issue with pending_keys occurs while a full-export packet is being produced, and manifests in the next hourly standalone packet. The sequence of events that causes missing data is as follows:

 1. A full export starts.
 2. The pending_keys table is dumped for the full-export packet.
 3. Concurrent recordchange calls (which apply to the next standalone packet) insert into the pending_keys table, but insertions for table names that already exist are skipped due to the "ON CONFLICT DO NOTHING" clause.
 4. The pending_keys table is cleared within the full-export transaction.
 5. The full-export transaction commits.

Any table names inserted between steps 3 and 4 which are skipped due to the "ON CONFLICT DO NOTHING" clause won't appear in the next standalone packet's pending_keys. (Concurrent pending_keys insertions after step 4 are not an issue, because they are blocking if they conflict.)

It's not necessary to log pending_keys data in recordchange. We can simply calculate it from pending_data when producing the packet in ExportAllTables (from within its serializable transaction).