### PR TITLE
Add sanitization test

### DIFF
--- a/test/sanitization/schema.sql
+++ b/test/sanitization/schema.sql
@@ -1,0 +1,27 @@
+CREATE schema musicbrainz;
+
+SET search_path = musicbrainz;
+
+CREATE TABLE editor (id INTEGER, name TEXT, password TEXT);
+ALTER TABLE editor ADD CONSTRAINT editor_pkey PRIMARY KEY (id);
+
+CREATE FUNCTION sanitize_editor(e editor)
+RETURNS editor
+LANGUAGE sql
+STABLE
+STRICT
+PARALLEL SAFE
+AS $$ SELECT ROW(e.id, e.name, NULL::TEXT)::editor $$;
+
+CREATE OR REPLACE FUNCTION sanitize_dbmirror2_editor()
+RETURNS trigger AS $$
+BEGIN
+    NEW.olddata = row_to_json(sanitize_editor(json_populate_record(NULL::editor, NEW.olddata)));
+    NEW.newdata = row_to_json(sanitize_editor(json_populate_record(NULL::editor, NEW.newdata)));
+    IF NEW.op = 'u' AND NEW.olddata::JSONB = NEW.newdata::JSONB THEN
+        -- Only sanitized columns have changed. No need to log the update.
+        RETURN NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';

--- a/test/sanitization/setup.sql
+++ b/test/sanitization/setup.sql
@@ -1,0 +1,26 @@
+SET search_path = musicbrainz;
+
+INSERT INTO editor
+VALUES (1, 'foo', NULL), (2, 'bar', NULL);
+
+CREATE TRIGGER reptg2_editor
+AFTER INSERT OR DELETE OR UPDATE ON editor
+FOR EACH ROW EXECUTE PROCEDURE dbmirror2.recordchange();
+
+CREATE TRIGGER sanitize_dbmirror2_editor
+BEFORE INSERT ON dbmirror2.pending_data
+FOR EACH ROW
+WHEN (NEW.tablename = 'musicbrainz.editor')
+EXECUTE PROCEDURE sanitize_dbmirror2_editor();
+
+UPDATE editor SET password = '123' WHERE id = 1;
+DELETE FROM editor WHERE id = 2;
+INSERT INTO editor VALUES (3, 'baz', '456');
+
+DROP TRIGGER reptg2_editor ON editor;
+
+TRUNCATE editor;
+
+-- Add back the initial data so we can replay the logged changes against it.
+INSERT INTO editor
+VALUES (1, 'foo', NULL), (2, 'bar', NULL);

--- a/test/sanitization/test.sql
+++ b/test/sanitization/test.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+SET search_path = musicbrainz, public;
+
+SELECT plan(3);
+
+SELECT is((SELECT password FROM editor WHERE id = 1), NULL);
+SELECT is((SELECT EXISTS (SELECT 1 FROM editor WHERE id = 2)), FALSE);
+SELECT is((SELECT password FROM editor WHERE id = 3), NULL);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
To address the issue with `editor` and `recording_first_release_date` described in [SEARCH-756](https://tickets.metabrainz.org/browse/SEARCH-756), the simplest option would be to add `recordchange` triggers on these tables.

Initially, we can have `admin/ExportAllTables` in musicbrainz-server strip these tables from replication packets before producing the archives (though I think it'd makes sense to at least include `editor` in the future). But we should first ensure that no unsanitized editor data makes its way into the `dbmirror2.pending_data` or `sir.pending_data` tables to begin with.

This commit adds a proof of concept for sanitizing `olddata` / `newdata` in the pending data table.